### PR TITLE
Master api

### DIFF
--- a/public/include/class.api.php
+++ b/public/include/class.api.php
@@ -441,7 +441,10 @@ class API
         if (count($required) > 0) {
             // We haven't fulfilled all required fields!
             // We'll leave the session lingering in the case they want to resubmit.
-            API::reply(400, API::makeResponse(400, "Required fields are not fulfilled."), APP_API);
+            $details = implode("; ", array_map(function ($field) {
+                return "xsdmf_id: {$field['xsdmf_id']} ('{$field['xsdmf_title']}')";
+            }, $required));
+            API::reply(400, API::makeResponse(400, "Required fields are not fulfilled: " . $details), APP_API);
             exit;
         }
 

--- a/public/templates/en/view.tpl.xml
+++ b/public/templates/en/view.tpl.xml
@@ -107,7 +107,7 @@
                         {* Name of file *}
                         {if $datastreams[d].isViewer == 1 || $isAdministrator}
                             <href>
-                                {$rel_url}eserv/{$pid}/{$ds_show}{if $viewingPreviousVersion}?version_date={$versionDate}{/if}
+                                {$rel_url}view/{$pid}/{$ds_show}{if $viewingPreviousVersion}?version_date={$versionDate}{/if}
                             </href>
                         {/if}
 
@@ -115,7 +115,7 @@
                             && $datastreams[d].stream != "0"
                             && $ds_show_extra != ''}
                             <href>
-                                {$rel_url}eserv/{$pid}/{$ds_show_extra}{if $viewingPreviousVersion}?version_date={$versionDate}{/if}
+                                {$rel_url}view/{$pid}/{$ds_show_extra}{if $viewingPreviousVersion}?version_date={$versionDate}{/if}
                             </href>
                         {/if}
 
@@ -123,7 +123,7 @@
                         {if ($datastreams[d].isArchivalViewer == 1 || $isAdministrator)
                             && $datastreams[d].thumbnail != "0"}
                             <href>
-                                {$rel_url}eserv/{$pid}/{$datastreams[d].ID}{if $viewingPreviousVersion}?version_date={$versionDate}{/if}
+                                {$rel_url}view/{$pid}/{$datastreams[d].ID}{if $viewingPreviousVersion}?version_date={$versionDate}{/if}
                             </href>
                         {/if}
 

--- a/public/templates/en/view_metadata.tpl.xml
+++ b/public/templates/en/view_metadata.tpl.xml
@@ -21,7 +21,7 @@
                         {/if}
                     </xsdmf_title>
                     {if $xsd_display_fields[i].xsdmf_data_type == 'date'}
-                            <xsdmf_value>
+                            <xsdmf_value>{strip}
                                 {if $xsd_display_fields[i].xsdmf_html_input == 'date'}
                                     {$details[$temp_fld_id]}
                                 {else}
@@ -31,13 +31,9 @@
                                         {$details[$temp_fld_id]}
                                     {/if}
                                 {/if}
-                            </xsdmf_value>
+                            {/strip}</xsdmf_value>
                     {else}
-                            <xsdmf_value>
-                                <![CDATA[
-                                    {$details[$temp_fld_id] nofilter}
-                                ]]>
-                            </xsdmf_value>
+                            <xsdmf_value>{strip}<![CDATA[{$details[$temp_fld_id] nofilter}]]>{/strip}</xsdmf_value>
                     {/if}
                 </xsd_display_field>
             {/if}

--- a/public/templates/en/workflow/edit_security.tpl.xml
+++ b/public/templates/en/workflow/edit_security.tpl.xml
@@ -65,7 +65,7 @@
                     <xsdel_title>{$field.xsdsel_title}</xsdel_title>
                     <xsdmf_invsible>{$field.xsdmf_invisible}</xsdmf_invsible>
                     <xsdmf_required>{$field.xsdmf_required}</xsdmf_required>
-                    <xsdmf_html_input>
+                    <xsdmf_html_input>{strip}
                         {* For dates we need to specify the type of date eg. year (date_type = 0) or a full date 01/01/2014 (date_type = 1) *}
                         {if $field.xsdmf_html_input == 'date'}
                             {if ($field.xsdmf_date_type == 0) or ($field.xsdmf_date_type == '')}
@@ -76,21 +76,17 @@
                         {else}
                             {$field.xsdmf_html_input}
                         {/if}
-                    </xsdmf_html_input>
+                    {/strip}</xsdmf_html_input>
                     <xsdmf_enabled>{$field.xsdmf_enabled}</xsdmf_enabled>
                     <field_options>
                         {if ($field.xsdmf_html_input == 'contvocab_selector')}
                             <uri>
-                                <![CDATA[
-                                    {$rel_url}cv_selector.php?parent_id={$field.xsdmf_cvo_id}&form=wfl_form1&element=xsd_display_fields_{$field.xsdmf_id}_0&xsdmf_cvo_min_level={$field.xsdmf_cvo_min_level}
-                                ]]>
+                                <![CDATA[{$rel_url}cv_selector.php?parent_id={$field.xsdmf_cvo_id}&form=wfl_form1&element=xsd_display_fields_{$field.xsdmf_id}_0&xsdmf_cvo_min_level={$field.xsdmf_cvo_min_level}]]>
                             </uri>
                         {/if}
                         {if ($field.xsdmf_html_input == 'file_input' && $field.xsdmf_title == 'File Upload')}
                             <uri>
-                                <![CDATA[
-                                    {$rel_url}uploader_upload_files.php?workflowId={$id}&xsdmf_id={$field.xsdmf_id}&fileNumber=0
-                                ]]>
+                                <![CDATA[{$rel_url}uploader_upload_files.php?workflowId={$id}&xsdmf_id={$field.xsdmf_id}&fileNumber=0]]>
                             </uri>
                         {/if}
                         {foreach from=$field.field_options item=option key=value}

--- a/public/templates/en/workflow/edit_security.tpl.xml
+++ b/public/templates/en/workflow/edit_security.tpl.xml
@@ -104,6 +104,32 @@
                     <xsdmf_long_description><![CDATA[{$field.xsdmf_long_description}]]></xsdmf_long_description>
                     <xsdmf_multiple>{$field.xsdmf_multiple}</xsdmf_multiple>
                     <xsdmf_cso_value>{$field.xsdmf_cso_value}</xsdmf_cso_value>{*checkbox value*}
+                    {if is_array($details[$temp_fld_id])}
+                        {if ($field.xsdmf_html_input == 'contvocab_selector')}
+                        {foreach from=$details[$temp_fld_id] key=cvo_id item=name }
+                        <xsdmf_value><![CDATA[{$cvo_id}]]></xsdmf_value>
+                        {/foreach}
+                        {else}
+                        {section loop=$details[$temp_fld_id] name=i}
+                        <xsdmf_value><![CDATA[{$details[$temp_fld_id][i]}]]></xsdmf_value>
+                        {sectionelse}
+                        <xsdmf_value></xsdmf_value>
+                        {/section}
+                        {/if}
+                    {else}
+                        {if $field.xsdmf_html_input == 'date'}
+                            {* We have detected a specific date format, so present this in xml (for APP_API). *}
+                            {if $field.xsdmf_html_input_date_format == 'YYY-MM-DD'}
+                                <xsdmf_value>{$details[$temp_fld_id]|smarty:nodefaults}</xsdmf_value>
+                            {elseif $field.xsdmf_html_input_date_format == 'YYY'}
+                                <xsdmf_value>{$details[$temp_fld_id]|smarty:nodefaults}</xsdmf_value>
+                            {else}
+                                <xsdmf_value>{$details[$temp_fld_id]|smarty:nodefaults}</xsdmf_value>
+                            {/if}
+                        {else}
+                            <xsdmf_value>{$details[$temp_fld_id]}</xsdmf_value>
+                        {/if}
+                    {/if}
                     <xsdmf_static_text>{$field.xsdmf_static_text}</xsdmf_static_text>
                     <multiple_array_input>
                         {if $field.xsdmf_multiple == 1}

--- a/public/templates/en/workflow/edit_security.tpl.xml
+++ b/public/templates/en/workflow/edit_security.tpl.xml
@@ -120,11 +120,11 @@
                         {if $field.xsdmf_html_input == 'date'}
                             {* We have detected a specific date format, so present this in xml (for APP_API). *}
                             {if $field.xsdmf_html_input_date_format == 'YYY-MM-DD'}
-                                <xsdmf_value>{$details[$temp_fld_id]|smarty:nodefaults}</xsdmf_value>
+                                <xsdmf_value>{$details[$temp_fld_id] nofilter}</xsdmf_value>
                             {elseif $field.xsdmf_html_input_date_format == 'YYY'}
-                                <xsdmf_value>{$details[$temp_fld_id]|smarty:nodefaults}</xsdmf_value>
+                                <xsdmf_value>{$details[$temp_fld_id] nofilter}</xsdmf_value>
                             {else}
-                                <xsdmf_value>{$details[$temp_fld_id]|smarty:nodefaults}</xsdmf_value>
+                                <xsdmf_value>{$details[$temp_fld_id] nofilter}</xsdmf_value>
                             {/if}
                         {else}
                             <xsdmf_value>{$details[$temp_fld_id]}</xsdmf_value>

--- a/public/templates/en/workflow/enter_metadata.tpl.xml
+++ b/public/templates/en/workflow/enter_metadata.tpl.xml
@@ -33,7 +33,7 @@
                     <xsdmf_title>{$field.xsdmf_title}</xsdmf_title>
                     <xsdmf_invsible>{$field.xsdmf_invisible}</xsdmf_invsible>
                     <xsdmf_required>{$field.xsdmf_required}</xsdmf_required>
-                    <xsdmf_html_input>
+                    <xsdmf_html_input>{strip}
                         {* For dates we need to specify the type of date eg. year (date_type = 0) or a full date 01/01/2014 (date_type = 1) *}
                         {if $field.xsdmf_html_input == 'date'}
                             {if ($field.xsdmf_date_type == 0) or ($field.xsdmf_date_type == '')}
@@ -44,18 +44,18 @@
                         {else}
                             {$field.xsdmf_html_input}
                         {/if}
-                    </xsdmf_html_input>
+                    {/strip}</xsdmf_html_input>
                     <xsdmf_enabled>{$field.xsdmf_enabled}</xsdmf_enabled>
                     <field_options>
                         {if ($field.xsdmf_html_input == 'contvocab_selector')}
-                            <uri>
+                            <uri>{strip}
                                 <![CDATA[{$rel_url}cv_selector.php?parent_id={$field.xsdmf_cvo_id}&form=wfl_form1&element=xsd_display_fields_{$field.xsdmf_id}_0&xsdmf_cvo_min_level={$field.xsdmf_cvo_min_level}]]>
-                            </uri>
+                            {/strip}</uri>
                         {/if}
                         {if ($field.xsdmf_html_input == 'file_input' && $field.xsdmf_title == 'File Upload')}
-                            <uri>
+                            <uri>{strip}
                                 <![CDATA[{$rel_url}uploader_upload_files.php?format=xml&workflowId={$id}&xsdmf_id={$field.xsdmf_id}&fileNumber=0]]>
-                            </uri>
+                            {/strip}</uri>
                         {/if}
                         {foreach from=$field.field_options item=option key=value}
                             {if ($option != '')}
@@ -175,16 +175,12 @@
 
             {if ( ($datastreams[d].isEditor == 1) || $isAdministrator )}
                 <delete_uri>
-                    <![CDATA[
-                        {$rel_url}popup.php?cat=delete_datastream&pid={$pid}&dsID={$datastreams[d].ID}
-                    ]]>
+                    <![CDATA[{$rel_url}popup.php?cat=delete_datastream&pid={$pid}&dsID={$datastreams[d].ID}]]>
                 </delete_uri>
             {/if}
             {if ($isSuperAdministrator)}
                 <purge_uri>
-                    <![CDATA[
-                        {$rel_url}popup.php?cat=purge_datastream&pid={$pid}&dsID={$datastreams[d].ID}
-                    ]]>
+                    <![CDATA[{$rel_url}popup.php?cat=purge_datastream&pid={$pid}&dsID={$datastreams[d].ID}]]>
                 </purge_uri>
             {/if}
             <permission>
@@ -206,9 +202,7 @@
             {section name="w" loop=$datastreams[d].workflows}
                 {if $datastreams[d].isEditor == 1 || $isAdministrator}
                     <edit_permission_uri>
-                        <![CDATA[
-                            {$rel_url}workflow/update.php?pid={$pid}&dsID={$datastreams[d].ID}&cat=select_workflow&wft_id={$datastreams[d].workflows[w].wft_id}&href={$smarty.server.REQUEST_URI}
-                        ]]>
+                        <![CDATA[{$rel_url}workflow/update.php?pid={$pid}&dsID={$datastreams[d].ID}&cat=select_workflow&wft_id={$datastreams[d].workflows[w].wft_id}&href={$smarty.server.REQUEST_URI}]]>
                     </edit_permission_uri>
                 {/if}
             {/section}
@@ -218,7 +212,5 @@
 </datastreams>
 
 <internal_notes>
-    <![CDATA[
-        {$internal_notes}
-    ]]>
+    <![CDATA[{$internal_notes}]]>
 </internal_notes>

--- a/public/workflow/edit_metadata.php
+++ b/public/workflow/edit_metadata.php
@@ -152,6 +152,11 @@ foreach ($_SESSION[APP_INTERNAL_GROUPS_SESSION] as $groupID) {
     }
 }
 
+if (APP_API) {
+    // Expose this to enter_metadata.tpl.xml for exposing purge_uri.
+    $tpl->assign("isSuperAdministrator", $isSuperAdministrator);
+}
+
 // Record the Internal Note, if we've been handed one.
 //if (isset($_POST['internal_notes']) && User::isUserAdministrator($username)) {
 if (isset($_POST['internal_notes']) && $record->canEdit()) {


### PR DESCRIPTION
Hi Guys,
Here are some more changes to files in fez as a result of me running tests in api/tests.

All commits have message "API: ..." which means they affect fez code - mostly xml templates and class.api, but also some other more core code.

I don't necessarily expect this to be merged in automatically because some of these commits may be problematic.  I'll point out the ones I think are potential issues:

283214b - security template - had to put in xsdmf_value tags.  Kind of pulled this in based on enter_metadata.tpl.xml
69ee4f7 - I couldn't get purge_uri to show for super administrator in the API / xml output without assigning it.  But maybe there is something I'm missing here.
2e30a70 - we were using attachment urls with /eserv/... in them and they weren't working, but I can see that urls use /view/... in the html templates.  So I've changed these to use /view/... in the xml templates.  It made my tests green at any rate :)
1dd3183 - so for a long time we would use "{...|smarty:nodefaults}" but that now causes fatal errors in smarty, so i've switched it to " nofilter".  Maybe this isn't problematic, but it's possible there may be more lurking - at least in our downstream code.  Did we update the smarty stack or something?

So, if you're time constrained and you're not happy with these, let me know, and I'll see if I can review them again.

Regards,
Daniel