### PR TITLE
FIX: make $isSuperAdministrator available to edit metadata template to show purge datastream link.

### DIFF
--- a/public/workflow/edit_metadata.php
+++ b/public/workflow/edit_metadata.php
@@ -152,10 +152,7 @@ foreach ($_SESSION[APP_INTERNAL_GROUPS_SESSION] as $groupID) {
     }
 }
 
-if (APP_API) {
-    // Expose this to enter_metadata.tpl.xml for exposing purge_uri.
-    $tpl->assign("isSuperAdministrator", $isSuperAdministrator);
-}
+$tpl->assign("isSuperAdministrator", $isSuperAdministrator);
 
 // Record the Internal Note, if we've been handed one.
 //if (isset($_POST['internal_notes']) && User::isUserAdministrator($username)) {


### PR DESCRIPTION
Hi Guys,
Purge datastream link doesn't show if this isn't set.
To replicate, edit a record with an attachment as a super administrator.  The purge datastream link will not show unless $isSuperAdministrator is set.