### PR TITLE
FIX: Fetch actual template path in Smarty.

### DIFF
--- a/public/include/class.template.php
+++ b/public/include/class.template.php
@@ -105,9 +105,9 @@ class Template_API
 	 * @access public
 	 * @param  string $tpl_name The filename of the template
 	 */
-	function setTemplate($tpl_name)
+	function setTemplate($tpl_name, $idx = 0)
 	{
-		$_curr_path = $this->smarty->template_dir;
+		$_curr_path = $this->smarty->getTemplateDir($idx);
 		if (!empty($this->smarty->custom_view_dir)) {
 			$_fullpath = $_curr_path . "/". $this->smarty->custom_view_dir. "/" .  $tpl_name;
 			if (file_exists($_fullpath) && is_file($_fullpath)) {


### PR DESCRIPTION
Hi Guys,
Custom views don't work for me without a change like the diff I have here.  I think smarty's template_dir is an array and returns an array which messes up getTemplate when it tries to figure out the path.  Even with non-custom stuff, getTemplate for my fez is not setting a fullpath because of this issue.
I gather you have custom views that do work, so I'm not sure if you are doing something different.  This behaviour is coming from a downstream fez with lots of modifications.

Not sure about the numeric indexes - it seems to be that way here.  But the example here:
http://www.smarty.net/docs/en/api.get.template.dir.tpl uses other keys.

Please test if you pull this in!

Regards,
Daniel