### PR TITLE
Scopus API: error-handling and varying records per request.

### DIFF
--- a/public/templates/en/manage/configuration.tpl.html
+++ b/public/templates/en/manage/configuration.tpl.html
@@ -2349,6 +2349,14 @@ function restoreDefaultColours(el)
               {include file="error_icon.tpl.html" field="app_scopus_import_collection"}
             </td>
           </tr>
+          <tr>
+            <th>Scopus API records fetched per request</th>
+            <td>
+              <input type="text" name="app_scopus_api_records_per_request" value="{$config_settings.app_scopus_api_records_per_request}" size="5" />
+              <br />Records to fetch per request to Scopus API.
+              {include file="error_icon.tpl.html" field="app_scopus_api_records_per_request"}
+            </td>
+          </tr>
 		  </tbody>
 		 </table>
 		</div>

--- a/public/upgrade/sql_scripts/upgrade2016042200.sql
+++ b/public/upgrade/sql_scripts/upgrade2016042200.sql
@@ -1,0 +1,2 @@
+insert ignore into %TABLE_PREFIX%config (config_name, config_module, config_value)
+       values ('app_scopus_api_records_per_request', 'core', 100);


### PR DESCRIPTION
Hi Guys,
I wanted to tighten up the scopus citation fetching code because I was having issues with the max number of scopus id's per request to scopus, and also because I think zero counts were being inserted when credentials weren't correct.  So, the patch would be something like below.

I can split it into the max request setting and the error-checking bits separately if that's preferred.

To test it, try changing api credentials and checking the fez application log.  For us, if the number of pids per request to scopus is too high, we may also get a service level error.