### PR TITLE
Bug fix to prevent unnecessary Auth Reindex

### DIFF
--- a/public/include/class.auth_index.php
+++ b/public/include/class.auth_index.php
@@ -201,8 +201,8 @@ class AuthIndex
 			// check if the auth rules have changed for this pid
 			// - if they haven't then we don't need to recurse.
 			$res = array();
-			$stmt = "SELECT * ".
-                    "FROM {$dbtp}auth_index2 WHERE authi_pid=?";
+			$stmt = "SELECT authi_pid, aro_role as authi_role, authi_arg_id FROM {$dbtp}auth_index2 i
+                JOIN {$dbtp}auth_roles r ON r.aro_id = i.authi_role  WHERE authi_pid=?"; 
 			try {
 				$res = $db->fetchAll($stmt, array($pid));
 			}
@@ -319,7 +319,9 @@ class AuthIndex
 			foreach ($children as $child_pid) {
 				$auth_index = new AuthIndex;
         		$auth_index->setBGP($this->bgp);
-        		$auth_index->setIndexAuthBGP($child_pid, $recurse);
+        		// Set topcall to false since we are now recursing to child records
+            $topcall = false;
+        		$auth_index->setIndexAuthBGP($child_pid, $recurse, $topcall);
 			}
 
 			if( APP_FILECACHE == "ON" ) {


### PR DESCRIPTION
Problem:  when selecting a collection or community to reindex, Fez is
doing an Auth Reindex of all files in that community/collection - even
when there are no authorisation changes for that collection.   There
were two problems: 1) the function setIndexAuthBGP is called within
setIndexAuthBGP for recursion, but $topcall is not included in the call.
Since the default value is true, the function always thinks it is the
top call.  Topcall is now included in the recursive call, set to false.
2) the part of the script that was comparing the fez_auth_index2 table
to the Fedora values was flawed because it was comparing authi_role as
an integer (from the database) and a text string from Fedora.  The
database query has been altered to fetch the text string.